### PR TITLE
fix: always use u32 to index arrays

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -1,8 +1,8 @@
-unconstrained fn __get_shuffle_indices<T, let N: u32>(lhs: [T; N], rhs: [T; N]) -> [Field; N]
+unconstrained fn __get_shuffle_indices<T, let N: u32>(lhs: [T; N], rhs: [T; N]) -> [u32; N]
 where
     T: std::cmp::Eq,
 {
-    let mut shuffle_indices: [Field; N] = [0; N];
+    let mut shuffle_indices: [u32; N] = [0; N];
 
     let mut shuffle_mask: [bool; N] = [false; N];
     for i in 0..N {
@@ -11,7 +11,7 @@ where
             if ((shuffle_mask[j] == false) & (!found)) {
                 if (lhs[i] == rhs[j]) {
                     found = true;
-                    shuffle_indices[i] = j as Field;
+                    shuffle_indices[i] = j;
                     shuffle_mask[j] = true;
                 }
             }
@@ -25,11 +25,11 @@ where
     shuffle_indices
 }
 
-unconstrained fn __get_index<let N: u32>(indices: [Field; N], idx: Field) -> Field {
+unconstrained fn __get_index<let N: u32>(indices: [u32; N], idx: u32) -> u32 {
     let mut result = 0;
     for i in 0..N {
         if (indices[i] == idx) {
-            result = i as Field;
+            result = i;
             break;
         }
     }
@@ -44,9 +44,9 @@ where
     let shuffle_indices = unsafe { __get_shuffle_indices(lhs, rhs) };
 
     for i in 0..N {
-        let idx = unsafe { __get_index(shuffle_indices, i as Field) };
+        let idx = unsafe { __get_index(shuffle_indices, i) };
         // checks the relation between shuffle_indices and output of __get_index
-        assert_eq(shuffle_indices[idx], i as Field);
+        assert_eq(shuffle_indices[idx], i);
     }
     for i in 0..N {
         let idx = shuffle_indices[i];
@@ -57,15 +57,15 @@ where
     }
 }
 
-pub fn get_shuffle_indices<T, let N: u32>(lhs: [T; N], rhs: [T; N]) -> [Field; N]
+pub fn get_shuffle_indices<T, let N: u32>(lhs: [T; N], rhs: [T; N]) -> [u32; N]
 where
     T: std::cmp::Eq,
 {
     //@Safety: as explained in check_shuffle function
     let shuffle_indices = unsafe { __get_shuffle_indices(lhs, rhs) };
     for i in 0..N {
-        let idx = unsafe { __get_index(shuffle_indices, i as Field) };
-        assert_eq(shuffle_indices[idx], i as Field);
+        let idx = unsafe { __get_index(shuffle_indices, i) };
+        assert_eq(shuffle_indices[idx], i);
     }
     for i in 0..N {
         let idx = shuffle_indices[i];


### PR DESCRIPTION
# Description

## Problem

Towards https://github.com/noir-lang/noir/pull/7908

## Summary



## Additional Context



# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
